### PR TITLE
AB#1803 - remove traversal join from docs

### DIFF
--- a/docs/jupiterone-query-language.md
+++ b/docs/jupiterone-query-language.md
@@ -60,7 +60,7 @@ boundaries obvious to query authors.
 > - The `undefined` keyword can be used to filter on the absence of a property.
 >   For example: `FIND DataStore with encrypted=undefined`
 > - If a property name contains special characters (e.g. `-` or `:`), you can
->   wrap the property name in `[]`.  
+>   wrap the property name in `[]`.
 >   For example: `[tag.special-name]='something'`
 
 `AND`, `OR` for multiple property comparisons are supported.
@@ -134,7 +134,7 @@ boundaries obvious to query authors.
 >
 > - `FIND Firewall AS fw THAT ALLOWS AS rule * AS n`
 
-`WHERE` is used for post-traversal filtering or union (requires selector)
+`WHERE` is used for post-traversal filtering (requires selector)
 
 > From the example above:
 >
@@ -143,15 +143,7 @@ boundaries obvious to query authors.
 >   WHERE rule.ingress=true AND
 >     (rule.fromPort=22 or rule.toPort=22)
 > ```
->
-> The following examples joins the properties of two different network entities,
-> to identify if there are multiple networks in the same environment using
-> conflicting IP spacing:
->
-> ```j1ql
-> FIND (Network as n1 | Network as n2)
->   WHERE n1.CIDR = n2.CIDR
-> ```
+
 
 `RETURN` is used to return specific entities, relationships, or properties
 
@@ -349,7 +341,7 @@ J1QL supports basic math operations on the return values.
 
 - The operation only works against number values. It will not work against
   strings or strings that represent numbers:
-  
+
   > `'1'` will not work, has to be `1`
 
 Example query:


### PR DESCRIPTION
I've verified that users are no longer using these queries (which never _really_ worked) and they are not being used in any automated queries. The latest instances in which they were used by customer was back in late October. If I recall correctly, better more efficient solutions were found for the customers that did use these queries (cc @a-u-h-g). Given to push to move towards the new execution engine (which at the moment does not support traversal joins), I think it's safe for us to effectively remove kill off this feature for now and re-introduce it at a later date once we are able to more effectively provide a better implementation.