### PR TITLE
Updating question defintions prior to releasing DeMorgan's law fix

### DIFF
--- a/docs/jupiterone-query-language.md
+++ b/docs/jupiterone-query-language.md
@@ -82,7 +82,7 @@ boundaries obvious to query authors.
   >
   >  Find Host WITH tag.Environment = ('A' or 'B' or 'C')
   >
-  >  Find DataStore WITH classification != ('critical' and 'restricted')
+  >  Find DataStore WITH classification != ('critical' or 'restricted')
   >  ```
 
 - Property filters are evaluated according the following **order of operations**:

--- a/faqs/faqs-account-billing.md
+++ b/faqs/faqs-account-billing.md
@@ -51,9 +51,9 @@ billable entities:
 Find * with
   _source !^= 'system-' and
   _class != (
-    'Finding' and 'PR' and 'Image' and 
-    'NetworkInterface' and 'IpAddress' and 
-    'Record' and 'DomainRecord'
+    'Finding' or 'PR' or 'Image' or 
+    'NetworkInterface' or 'IpAddress' or 
+    'Record' or 'DomainRecord'
   ) as e
 return
   count(e) as billableEntityCount


### PR DESCRIPTION
Updating questions to reflect changes to language interpolation of negated shorthand filters to reflect DeMorgan's law. This includes flipping all AND/OR operators within a shorthand filter when negated equality is uses.

Other repositories with defined questions impacted by this ticket:
docs
insights-dashboard
integration-google-cloud
jupiter-integration-aws
jupiter-integration-jira
jupiterone-alert-rules
provision-managed-questions