### PR TITLE
Update refs from master -> main

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   npm:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:

--- a/src/util/buildIntegrationDocs.ts
+++ b/src/util/buildIntegrationDocs.ts
@@ -27,7 +27,7 @@ interface IntegrationProjectConfigRenderable extends IntegrationProjectConfig {
 }
 
 function buildGithubDocFileUrl(projectName: string) {
-  return `https://raw.githubusercontent.com/JupiterOne/${projectName}/master/docs/jupiterone.md`;
+  return `https://raw.githubusercontent.com/JupiterOne/${projectName}/main/docs/jupiterone.md`;
 }
 
 /**


### PR DESCRIPTION
I think the integration docs are probably borked because they're all trying to reference the `master` branch... unless there's some magic I'm missing.