### PR TITLE
Fix broken markdown links

### DIFF
--- a/docs/jupiterone-data-security.md
+++ b/docs/jupiterone-data-security.md
@@ -48,7 +48,7 @@ and relationships are the **JupiterOne CORE data model**.
 JupiterOne then uses this data model to inventory for and provide insight into
 your digital infrastructure across all of your connected environments.
 
-More information on the JupiterOne data model is available [here](jupiterone-data-model.md).
+More information on the JupiterOne data model is available [here](../jupiterone-data-model.md).
 
 For more details on data ingested for each managed integration, see their
 corresponding documentation in the **Integrations** section.
@@ -109,7 +109,7 @@ infrastructure-as-code operational model and automated change management process
 allows us to deploy security patches within minutes of identification and
 remediation of an issue.
 
-You can review the JupiterOne [data model](jupiterone-data-model.md) and [policies and procedures](https://psp.jptr.one/) for 
+You can review the JupiterOne [data model](../jupiterone-data-model.md) and [policies and procedures](https://psp.jptr.one/) for 
 more details on the JupiterOne operational, infrastructure, and software 
 development security.
 

--- a/guides/J1-what-is-it.md
+++ b/guides/J1-what-is-it.md
@@ -99,7 +99,7 @@ the text and lists any questions related to your keywords. ![](../assets/j1-ask-
 
 ## JupiterOne Query Language
 
-The [JupiterOne Query Language](../docs/jupiterone-query-language) (J1QL) is a query language for 
+The [JupiterOne Query Language](../docs/jupiterone-query-language.md) (J1QL) is a query language for 
 finding the entities and relationships within your digital 
 environment. J1QL blends together the capabilities of 
 asking questions, performing full text search, and querying 

--- a/guides/J1-what-is-it.md
+++ b/guides/J1-what-is-it.md
@@ -10,7 +10,7 @@ ultimate visibility to your environment, infrastructure, and operations.
 The first step in using J1 is to bring your data into J1. There are numerous 
 ready-made integrations that are easy to install and use to achieve 
 end-to-end cyber asset visibility, context, and automation across every 
-dimension of your digital universe. J1 provides [instructions](configure-integrations.md) on how 
+dimension of your digital universe. J1 provides [instructions](../configure-integrations.md) on how 
 to import the data to J1 and understand the data model and mapping.
 
 ## J1 Apps
@@ -23,7 +23,7 @@ security management. Click ![](../assets/icons/apps.png) to view the apps.
 ### Assets
 
 After you import your data, you can analyze and visualize your complete 
-infrastructure and [security cyber asset inventory](asset-inventory-filters.md) using the J1 Assets app. 
+infrastructure and [security cyber asset inventory](../asset-inventory-filters.md) using the J1 Assets app. 
 In addition, the Assets app helps you can understand the types and classes 
 of cyber assets you have, and the relationships between them. 
 
@@ -36,14 +36,14 @@ Each policy and procedure document is written in its own individual Markdown fil
 and you can configure each policy file to link to other files. The templates are 
 open-source that you can edit directly online using the Policies app.
 
-To help you get started, JupiterOne provides 120+ [policy and procedure templates](manage-policies/policies-app.md) to 
+To help you get started, JupiterOne provides 120+ [policy and procedure templates](../manage-policies/policies-app.md) to 
 help your organization build your security program and operations. These 
 templates derive from JupiterOne company internal policies and procedures, 
 and have been through several rounds of compliance assessments.
 
 ### Alerts
 
-JupiterOne enables you to [configure alert rules](manage-alerts.md) in the Alerts app, using any JupiterOne 
+JupiterOne enables you to [configure alert rules](../manage-alerts.md) in the Alerts app, using any JupiterOne 
 Query Language query for continuous auditing and threat monitoring. You must 
 have at least one active alert rule to trigger any alert. The easiest way to add some 
 rules to an alert is to import rule packs that JupiterOne provides. You can 
@@ -55,22 +55,22 @@ JupiterOne provides a flexible platform for you to manage any
 compliance standard or framework as a set of controls or requirements. 
 The platform enables you to:
 
-- [Import a compliance standard or security questionnaire](compliance/compliance-import.md)
-- [Map policy procedures to each control or requirement](compliance/compliance-mapping-policies.md)
-- [Map data-driven compliance evidence by query questions](compliance/compliance-mapping-evidence.md)
-- [Perform automated gap analysis based on query results](compliance/compliance-gap-analysis.md)
-- [Export compliance artifacts (summary or full evidence package)](compliance/compliance-export.md)
+- [Import a compliance standard or security questionnaire](../compliance/compliance-import.md)
+- [Map policy procedures to each control or requirement](../compliance/compliance-mapping-policies.md)
+- [Map data-driven compliance evidence by query questions](../compliance/compliance-mapping-evidence.md)
+- [Perform automated gap analysis based on query results](../compliance/compliance-gap-analysis.md)
+- [Export compliance artifacts (summary or full evidence package)](../compliance/compliance-export.md)
 
 ### Graph Viewer
 
-JupiterOne is built on a [data-driven graph](quickstart-graph.md) platform. JupiterOne Query Language (J1QL) is 
+JupiterOne is built on a [data-driven graph](../quickstart-graph.md) platform. JupiterOne Query Language (J1QL) is 
 designed to traverse this graph and return a sub-graph or data from the entities and 
 edges (such as relationships) of a sub-graph. You can view and interact with 
 the sub-graph from any J1QL query result.
 
 ### Insights
 
-The [JupiterOne Insights app](insights-dashboards.md) enables you to build reporting dashboards using J1QL queries.
+The [JupiterOne Insights app](../insights-dashboards.md) enables you to build reporting dashboards using J1QL queries.
 
 You can configure each dashboard as either a team board that is shared with other 
 account users or a personal board for the individual user. The layout of each board is 
@@ -105,7 +105,7 @@ environment. J1QL blends together the capabilities of
 asking questions, performing full text search, and querying 
 the complex entity-relationship graph.
 
-J1QL is complex but a [tutorial](tutorial-j1ql.md) is available to help you learn.
+J1QL is complex but a [tutorial](../tutorial-j1ql.md) is available to help you learn.
 In addition, JupiterOne offers [J1VQB](j1-vqb), a visual query building app,
 a codefree tool for creating queries.
 

--- a/guides/configure-integrations.md
+++ b/guides/configure-integrations.md
@@ -21,7 +21,7 @@ For details on other integrations, see the respective documentation under
 ## Other Data
 
 In addition,, you can upload data outside of these managed integrations using
-the JupiterOne [API client or CLI](j1-client-and-cli.md). This feature allows you to centrally track,
+the JupiterOne [API client or CLI](../j1-client-and-cli.md). This feature allows you to centrally track,
 monitor, and visualize any of your data, such as on-premise systems and security and
 compliance artifacts.
 

--- a/src/zendesk/config.yaml
+++ b/src/zendesk/config.yaml
@@ -92,7 +92,7 @@ sections:
         webLink: 'https://support.jupiterone.io/hc/en-us/articles/1500003848502'
       - title: Data Security
         file: ../docs/jupiterone-data-security.md
-        hash: NKnS4MvZy79WwiG54/x4964t4BOj+RShBvO9E1+QKKk=
+        hash: iGlXN0eWxCj/DLzSMOp19YZ6qvXlBqhHpACx9SgsW18=
         id: 360024092813
         webLink: 'https://support.jupiterone.io/hc/en-us/articles/360024092813'
   - name: Common Questions and Queries
@@ -326,7 +326,7 @@ sections:
     articles:
       - title: JupiterOne Platform API
         file: ../docs/jupiterone-api.md
-        hash: gEO/Uc61Nf4nRfmUbgiANEG98Xv0aVBwgWEZPwsr/WU=
+        hash: ISpTCKs+k4OJYWUgX8gld/oO31O7RvjcvGFmmQfp7nk=
         id: 360022722094
         webLink: 'https://support.jupiterone.io/hc/en-us/articles/360022722094'
       - title: JupiterOne Compliance API
@@ -783,7 +783,7 @@ sections:
         webLink: 'https://support.jupiterone.io/hc/en-us/articles/4406699567635'
       - title: 2021.78 Release
         file: ../release-notes/2021-78.md
-        hash: 2qyurQ1iP5SvPUmZiaL7O6ocqhWd/LAvRo4JOku5bWs=
+        hash: n7abBkU9Q6HMooKKGn45E4fZH0wyZ0zwOg5VNFBPouk=
         id: 4405894523667
         webLink: 'https://support.jupiterone.io/hc/en-us/articles/4405894523667'
       - title: 2021.77 Release

--- a/src/zendesk/config.yaml
+++ b/src/zendesk/config.yaml
@@ -4,13 +4,13 @@ sections:
     articles:
       - title: 00/10 Intro to JupiterOne
         file: ../guides/J1-what-is-it.md
-        hash: SinJVI9hJSHoa/Lxciqpl23ioUwXub4ZHRJ2UKAL2J8=
+        hash: ZAfTpC0DENdk8TfWKF2a/DID/HOQ9/dOm0d+7719kmw=
         id: 4407857686163
         webLink: 'https://support.jupiterone.io/hc/en-us/articles/4407857686163'
       - id: 360022884813
         title: 01/10 Configure Integrations
         file: ../guides/configure-integrations.md
-        hash: aRdCA0P1H3QRYbVDMaMXj6etXmxyN1mcSpjRtzLLEGg=
+        hash: tYNh0BaD/n2jFYiAYFa3fWddfr8lCtBBlNwC5TZ3+xQ=
         webLink: 'https://support.jupiterone.io/hc/en-us/articles/360022884813'
       - id: 360022705414
         title: 02/10 Search Quickstart
@@ -326,7 +326,7 @@ sections:
     articles:
       - title: JupiterOne Platform API
         file: ../docs/jupiterone-api.md
-        hash: KVx5AKZ8SjEcm0/qfP6/9VjHu4CISK6T+pbMFclWE/s=
+        hash: TAFwkEPMu0S0yZYukIaq1cneArTbV+Atc3oPzu4Br9k=
         id: 360022722094
         webLink: 'https://support.jupiterone.io/hc/en-us/articles/360022722094'
       - title: JupiterOne Compliance API
@@ -783,7 +783,7 @@ sections:
         webLink: 'https://support.jupiterone.io/hc/en-us/articles/4406699567635'
       - title: 2021.78 Release
         file: ../release-notes/2021-78.md
-        hash: b+7NKdHM2swTN1Ec8E9uQAABy/B3HKMXLgvGmrs8pT4=
+        hash: WeUnsVuj3VLamNdKljQOOoPZZVkWsD1xV7R/z8cTLmI=
         id: 4405894523667
         webLink: 'https://support.jupiterone.io/hc/en-us/articles/4405894523667'
       - title: 2021.77 Release

--- a/src/zendesk/config.yaml
+++ b/src/zendesk/config.yaml
@@ -4,7 +4,7 @@ sections:
     articles:
       - title: 00/10 Intro to JupiterOne
         file: ../guides/J1-what-is-it.md
-        hash: svHM6Ij2gbZU9SywsoFMp8s9Ls1RHFZhvTLWKwWnAW4=
+        hash: SinJVI9hJSHoa/Lxciqpl23ioUwXub4ZHRJ2UKAL2J8=
         id: 4407857686163
         webLink: 'https://support.jupiterone.io/hc/en-us/articles/4407857686163'
       - id: 360022884813
@@ -326,7 +326,7 @@ sections:
     articles:
       - title: JupiterOne Platform API
         file: ../docs/jupiterone-api.md
-        hash: ISpTCKs+k4OJYWUgX8gld/oO31O7RvjcvGFmmQfp7nk=
+        hash: KVx5AKZ8SjEcm0/qfP6/9VjHu4CISK6T+pbMFclWE/s=
         id: 360022722094
         webLink: 'https://support.jupiterone.io/hc/en-us/articles/360022722094'
       - title: JupiterOne Compliance API
@@ -783,7 +783,7 @@ sections:
         webLink: 'https://support.jupiterone.io/hc/en-us/articles/4406699567635'
       - title: 2021.78 Release
         file: ../release-notes/2021-78.md
-        hash: n7abBkU9Q6HMooKKGn45E4fZH0wyZ0zwOg5VNFBPouk=
+        hash: b+7NKdHM2swTN1Ec8E9uQAABy/B3HKMXLgvGmrs8pT4=
         id: 4405894523667
         webLink: 'https://support.jupiterone.io/hc/en-us/articles/4405894523667'
       - title: 2021.77 Release


### PR DESCRIPTION
please use `../` at beginning when linking to markdown files in the future even when they are in the same directory to avoid this issue