### PR TITLE
Add Azure DevOps docs to build:docs:integration script

### DIFF
--- a/docs/integrations/azure-devops/index.md
+++ b/docs/integrations/azure-devops/index.md
@@ -1,3 +1,67 @@
+# Integration with JupiterOne
+
+## Azure DevOps + JupiterOne Integration Benefits
+
+- Visualize Azure DevOps projects, teams, and users in the JupiterOne graph.
+- Map Azure DevOps users to employees in your JupiterOne account.
+- Monitor changes to Azure DevOps users using JupiterOne alerts.
+
+## How it Works
+
+- JupiterOne periodically fetches projects, teams, and users from Azure DevOps
+  to update the graph.
+- Write JupiterOne queries to review and monitor updates to the graph, or
+  leverage existing queries.
+- Configure alerts to take action when JupiterOne graph changes, or leverage
+  existing alerts.
+
+## Requirements
+
+- The Azure DevOps + JupiterOne integration uses a read-only personal access
+  token to ingest data from the Azure DevOps platform. You must have access to
+  generate a personal access token in Azure DevOps
+- You must have permission in JupiterOne to install new integrations.
+
+## Support
+
+If you need help with this integration, please contact
+[JupiterOne Support](https://support.jupiterone.io).
+
+## Integration Walkthrough
+
+### In Azure DevOps
+
+1. [Generate a Personal Access Token (PAT)](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate)
+2. Grant the following permissions to your PAT:
+   - **Project and Team [read]**
+   - **Work Items [read]**
+
+### In JupiterOne
+
+1. From the configuration **Gear Icon**, select **Integrations**.
+2. Scroll to the **Azure DevOps** integration tile and click it.
+3. Click the **Add Configuration** button and configure the following settings:
+
+- Enter the **Account Name** by which you'd like to identify this Azure DevOps
+  account in JupiterOne. Ingested entities will have this value stored in
+  `tag.AccountName` when **Tag with Account Name** is checked.
+- Enter a **Description** that will further assist your team when identifying
+  the integration instance.
+- Select a **Polling Interval** that you feel is sufficient for your monitoring
+  needs. You may leave this as `DISABLED` and manually execute the integration.
+- Enter your account URL (_Example: "https://dev.azure.com/jupiterone"_)
+- Enter the **Personal Access Token** generated for use by JupiterOne.
+
+4. Click **Create Configuration** once all values are provided.
+
+# How to Uninstall
+
+1. From the configuration **Gear Icon**, select **Integrations**.
+2. Scroll to the **Azure DevOps** integration tile and click it.
+3. Identify and click the **integration to delete**.
+4. Click the **trash can** icon.
+5. Click the **Remove** button to delete the integration.
+
 <!-- {J1_DOCUMENTATION_MARKER_START} -->
 <!--
 ********************************************************************************

--- a/docs/integrations/azure-devops/index.md
+++ b/docs/integrations/azure-devops/index.md
@@ -38,7 +38,7 @@ If you need help with this integration, contact
 
 ### In JupiterOne
 
-1. From the settings menu [](../../assets/icons/gear.png), select **Integrations**.
+1. From the settings gear icon, select **Integrations**.
 2. Scroll down to **Azure DevOps** and click it.
 3. Click **Add Configuration** and configure the following settings:
 
@@ -55,7 +55,7 @@ If you need help with this integration, contact
 
 # How to Uninstall
 
-1. From the settings menu [](../../assets/icons/gear.png), select **Integrations**.
+1. From the settings gear icon, select **Integrations**.
 2. Scroll down to **Azure DevOps** and click it.
 3. Identify and click the **integration to delete**.
 4. Click the trash can icon.

--- a/docs/integrations/azure-devops/index.md
+++ b/docs/integrations/azure-devops/index.md
@@ -12,19 +12,19 @@
   to update the graph.
 - Write JupiterOne queries to review and monitor updates to the graph, or
   leverage existing queries.
-- Configure alerts to take action when JupiterOne graph changes, or leverage
+- Configure alerts to take action when a JupiterOne graph changes, or leverage
   existing alerts.
 
 ## Requirements
 
-- The Azure DevOps + JupiterOne integration uses a read-only personal access
+- The Azure DevOps + JupiterOne integration uses a read-only, personal access
   token to ingest data from the Azure DevOps platform. You must have access to
   generate a personal access token in Azure DevOps
 - You must have permission in JupiterOne to install new integrations.
 
 ## Support
 
-If you need help with this integration, please contact
+If you need help with this integration, contact
 [JupiterOne Support](https://support.jupiterone.io).
 
 ## Integration Walkthrough
@@ -33,34 +33,33 @@ If you need help with this integration, please contact
 
 1. [Generate a Personal Access Token (PAT)](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate)
 2. Grant the following permissions to your PAT:
-   - **Project and Team [read]**
-   - **Work Items [read]**
+   - Project and Team [read]
+   - Work Items [read]
 
 ### In JupiterOne
 
-1. From the configuration **Gear Icon**, select **Integrations**.
-2. Scroll to the **Azure DevOps** integration tile and click it.
-3. Click the **Add Configuration** button and configure the following settings:
+1. From the settings menu [](../../assets/icons/gear.png), select **Integrations**.
+2. Scroll down to **Azure DevOps** and click it.
+3. Click **Add Configuration** and configure the following settings:
 
-- Enter the **Account Name** by which you'd like to identify this Azure DevOps
-  account in JupiterOne. Ingested entities will have this value stored in
-  `tag.AccountName` when **Tag with Account Name** is checked.
-- Enter a **Description** that will further assist your team when identifying
-  the integration instance.
-- Select a **Polling Interval** that you feel is sufficient for your monitoring
-  needs. You may leave this as `DISABLED` and manually execute the integration.
-- Enter your account URL (_Example: "https://dev.azure.com/jupiterone"_)
-- Enter the **Personal Access Token** generated for use by JupiterOne.
+- Enter the account name by which you want to identify this Azure DevOps
+  account in JupiterOne. Select **Tag with Account Name** to store this value in 
+  `tag.AccountName` of the ingested assets.
+- Enter a description to assist your team identify the integration instance.
+- Select a polling interval that is sufficient for your monitoring
+  needs. You can leave this as `DISABLED` and manually execute the integration.
+- Enter your account URL (_Example: "https://dev.azure.com/jupiterone"_).
+- Enter the personal access token generated for use by JupiterOne.
 
-4. Click **Create Configuration** once all values are provided.
+4. Click **Create Configuration** after you have entered all the values.
 
 # How to Uninstall
 
-1. From the configuration **Gear Icon**, select **Integrations**.
-2. Scroll to the **Azure DevOps** integration tile and click it.
+1. From the settings menu [](../../assets/icons/gear.png), select **Integrations**.
+2. Scroll down to **Azure DevOps** and click it.
 3. Identify and click the **integration to delete**.
-4. Click the **trash can** icon.
-5. Click the **Remove** button to delete the integration.
+4. Click the trash can icon.
+5. Click **Remove** to delete the integration.
 
 <!-- {J1_DOCUMENTATION_MARKER_START} -->
 <!--

--- a/src/util/integrations.config.yaml
+++ b/src/util/integrations.config.yaml
@@ -7,6 +7,8 @@ integrations:
   displayName: Auth0
 - projectName: graph-azure
   displayName: Azure
+- projectName: graph-azure-devops
+  displayName: Azure DevOps
 - projectName: graph-bamboohr
   displayName: BambooHR
 - projectName: graph-bugcrowd


### PR DESCRIPTION
The `graph-azure-devops` project was not set up to automatically fetch new docs through the `build:docs:integrations` script. Added `graph-azure-devops` to the script and pulled the latest docs.