### PR TITLE
Adding documentation for finalization locking on scope

### DIFF
--- a/docs/jupiterone-api.md
+++ b/docs/jupiterone-api.md
@@ -939,6 +939,9 @@ are duplicate keys already in use.
 - Scope is required when the `syncMode` is `DIFF`.
 - Scope can only be used when the `source` is `api`.
 
+!!! warning
+    There can only be one sync job finalized under the same `scope` at a time. Multiple attempts to finalize a job under the same scope will result in a `400`.
+
 `syncMode`:
 
 - `DIFF` is the default value when a syncMode is not specified. This mode will

--- a/docs/jupiterone-api.md
+++ b/docs/jupiterone-api.md
@@ -940,7 +940,7 @@ are duplicate keys already in use.
 - Scope can only be used when the `source` is `api`.
 
 !!! warning
-    There can only be one sync job finalized under the same `scope` at a time. Multiple attempts to finalize a job under the same scope will result in a `400`.
+    There can only be one sync job finalizing under the same `scope` at a time. Multiple attempts to finalize a job under the same scope will result in a `400`.
 
 `syncMode`:
 


### PR DESCRIPTION
Updating the docs to reflect changes to the sync API to lock sync job finalization by scope: https://github.com/JupiterOne/jupiter-persister/pull/242