### PR TITLE
CORE-2568 - Add `includeDeleted` to alert rule `QuestionQuery`

### DIFF
--- a/knowledgeBase/APIs_and-integrations/APIs/alert-rule-schema.md
+++ b/knowledgeBase/APIs_and-integrations/APIs/alert-rule-schema.md
@@ -100,6 +100,7 @@ whose responses can be used in any `RuleOperation`.
 | `name?`   | `string` | Optional name to assign the query that will be used when referencing query data in `RuleOperation`s. If not provided, the query name is automatically assigned based on the index in the `queries` array (for example, `query0`, `query1`). |
 | `query`   | `string` | JupiterOne query to execute.             |
 | `version` | `string` | JupiterOne query language execution version (for example, `v1`). |
+| `includeDeleted` | `boolean` | Whether deleted data should be considered for the specific query (defaults to `false`). |
 
 ### Type: RuleOperationCondition
 


### PR DESCRIPTION
`includeDeleted` is now a supported property in alert rule queries.
When the `includeDeleted` value is `true`, the specific query will
allow deleted data to be considered.

Example:

```json
{
  "name": "aws-instance-deleted",
  "description": "Alert when deleted aws_instance entities found",
  "version": 1,
  "specVersion": 1,
  "pollingInterval": "ONE_DAY",
  "templates": {},
  "outputs": [
    "alertLevel"
  ],
  "question": {
    "queries": [
      {
        "name": "query0",
        "query": "FIND aws_instance WITH _deleted = true",
        "version": "v1",
        "includeDeleted": true
      }
    ]
  },
  "operations": [
    {
      "when": {
        "type": "FILTER",
        "specVersion": 1,
        "condition": "{{queries.query0.total > 0}}"
      },
      "actions": [
        {
          "targetValue": "CRITICAL",
          "type": "SET_PROPERTY",
          "targetProperty": "alertLevel"
        },
        {
          "type": "CREATE_ALERT"
        }
      ]
    }
  ]
}
```