### PR TITLE
add rate limit tiers to api docs

### DIFF
--- a/knowledgeBase/APIs/jupiterone-api.md
+++ b/knowledgeBase/APIs/jupiterone-api.md
@@ -8,7 +8,7 @@ The JupiterOne platform exposes a number of public GraphQL endpoints.
 
 **Endpoint for alert and rules operations**: `/rules/graphql`
 
-**Rate Limits**: Rate limiting is enforced based on your account tier. 
+**Rate Limits**: Rate limiting is enforced based on your account tier: 
 
 - Free: 10/min, no burst
 - Freemium: 30/min, no burst

--- a/knowledgeBase/APIs/jupiterone-api.md
+++ b/knowledgeBase/APIs/jupiterone-api.md
@@ -8,7 +8,13 @@ The JupiterOne platform exposes a number of public GraphQL endpoints.
 
 **Endpoint for alert and rules operations**: `/rules/graphql`
 
-**Rate Limits**: Rate limiting is enforced based on your account tier. A `429` HTTP response code indicates the limit has been reached. The API does not currently return any rate limit headers.
+**Rate Limits**: Rate limiting is enforced based on your account tier. 
+
+- Free: 10/min, no burst
+- Freemium: 30/min, no burst
+- Enterprise: 30-60/min with burst
+
+A `429` HTTP response code indicates the limit has been reached. The API does not currently return any rate limit headers.
 
 **Authentication**: The JupiterOne APIs use a Bearer Token to authenticate. Include the API key in the header as a Bearer Token. You also need to include `JupiterOne-Account` as a header parameter. You can find the `Jupiterone-Account` value in your account by running the following J1QL query:
 

--- a/knowledgeBase/APIs/jupiterone-compliance-api.md
+++ b/knowledgeBase/APIs/jupiterone-compliance-api.md
@@ -15,7 +15,13 @@ See the [JupiterOne Platform API](./jupiterone-api.md) for an introduction to th
 
 **Endpoint for compliance operations**: `/graphql`
 
-**Rate Limits**: Rate limiting is enforced based on your account tier. A `429` HTTP response code indicates the limit has been reached. The API does not currently return any rate limit headers.
+**Rate Limits**: Rate limiting is enforced based on your account tier. 
+
+- Free: 10/min, no burst
+- Freemium: 30/min, no burst
+- Enterprise: 30-60/min with burst
+
+A `429` HTTP response code indicates the limit has been reached. The API does not currently return any rate limit headers.
 
 ## List Frameworks
 

--- a/knowledgeBase/APIs/jupiterone-compliance-api.md
+++ b/knowledgeBase/APIs/jupiterone-compliance-api.md
@@ -15,7 +15,7 @@ See the [JupiterOne Platform API](./jupiterone-api.md) for an introduction to th
 
 **Endpoint for compliance operations**: `/graphql`
 
-**Rate Limits**: Rate limiting is enforced based on your account tier. 
+**Rate Limits**: Rate limiting is enforced based on your account tier: 
 
 - Free: 10/min, no burst
 - Freemium: 30/min, no burst


### PR DESCRIPTION
add rate limit tiers to api docs:
- API
- Compliance API
<img width="619" alt="api_preview_md" src="https://user-images.githubusercontent.com/23426865/172147544-4a0df586-33c8-46ea-89eb-8f7a232d9abc.png">
<img width="867" alt="compliance_api_preview_md" src="https://user-images.githubusercontent.com/23426865/172147549-bc20ccd9-5f07-4152-81ed-00b1beba7f5f.png">

