### PR TITLE
salesforce integration instructions update

### DIFF
--- a/knowledgeBase/APIs_and-integrations/CRM/graph-salesforce.md
+++ b/knowledgeBase/APIs_and-integrations/CRM/graph-salesforce.md
@@ -29,9 +29,9 @@ If you need help with this integration, please contact
 
 ## Integration Walkthrough
 
-### Salesforce Account Creation (if you already have a Salesforce developer account you can skip this part)
+### Salesforce Account Creation (if you already have a Salesforce developer account you can omit this step)
 
-1.  First navigate to the Salesforce developer account creation page or go to this webpage https://developer.salesforce.com/signup (note this must be a developer account.  The integration will not run if you create a generic salesforce account).
+1.  Navigate to the Salesforce developer account creation page or go to https://developer.salesforce.com/signup (note this must be a developer account. The integration does not run if you create a generic salesforce account).
 
 
 ### In JupiterOne
@@ -48,10 +48,10 @@ If you need help with this integration, please contact
 *   Select a **Polling Interval** that you feel is sufficient for your monitoring
     needs. You may leave this as `DISABLED` and manually execute the integration.
 
-4.  Click **Create Configuration** once all values are provided. Once the relevant form information has been filled out, submitting the form
-    will redirect the user to Salesforce to authorize the requested scopes. Click "Begin Authorization" to be redirected to Salesforce. From there log in     with your Salesforce developer account username and password.
+4.  Click **Create Configuration** after you have provided all the values. When you have entered the relevant form information, submitting the form
+    redirects you to Salesforce to authorize the requested scopes. Click "Begin Authorization" to be redirected to Salesforce. From there, log in with your Salesforce developer account username and password.
 
-6.  You may be directed back to Jupiter One to log in again.  After logging in you should be at the Salesforce Integration page again and your integration     can now be run.
+6.  You may be directed back to JupiterOne to sign in again. After signing in you are at the Salesforce Integration page again and your integration can now run.
 
 # How to Uninstall
 
@@ -59,7 +59,7 @@ If you need help with this integration, please contact
 2.  Scroll to the **Salesforce** integration tile and click it.
 3.  Identify and click the **integration to delete**.
 4.  Click the **trash can** icon.
-5.  Click the **Remove** button to delete the integration.
+5.  Click **Remove** to delete the integration.
 
 <!-- {J1_DOCUMENTATION_MARKER_START} -->
 

--- a/knowledgeBase/APIs_and-integrations/CRM/graph-salesforce.md
+++ b/knowledgeBase/APIs_and-integrations/CRM/graph-salesforce.md
@@ -29,16 +29,10 @@ If you need help with this integration, please contact
 
 ## Integration Walkthrough
 
-### In Salesforce
+### Salesforce Account Creation (if you already have a Salesforce developer account you can skip this part)
 
-1.  First navigate to the JupiterOne Salesforce integration configuration page
-    (see detailed steps in the **In JupiterOne** section below)
+1.  First navigate to the Salesforce developer account creation page or go to this webpage https://developer.salesforce.com/signup (note this must be a developer account.  The integration will not run if you create a generic salesforce account).
 
-2.  Once the relevant form information has been filled out, submitting the form
-    will redirect the user to Salesforce to authorize the requested scopes.
-
-3.  Review the request, click "Allow", and then you will be redirected back to
-    JupiterOne.
 
 ### In JupiterOne
 
@@ -54,7 +48,10 @@ If you need help with this integration, please contact
 *   Select a **Polling Interval** that you feel is sufficient for your monitoring
     needs. You may leave this as `DISABLED` and manually execute the integration.
 
-4.  Click **Create Configuration** once all values are provided.
+4.  Click **Create Configuration** once all values are provided. Once the relevant form information has been filled out, submitting the form
+    will redirect the user to Salesforce to authorize the requested scopes. Click "Begin Authorization" to be redirected to Salesforce. From there log in     with your Salesforce developer account username and password.
+
+6.  You may be directed back to Jupiter One to log in again.  After logging in you should be at the Salesforce Integration page again and your integration     can now be run.
 
 # How to Uninstall
 


### PR DESCRIPTION
updated salesforce integration walkthrough to specify that a salesforce developer account is needed (and not just a generic salesforce account as the user was previously directed to create) to successfully use the integration. Updated based on feedback from zemberdotnet and minor changes to increase accuracy.