### PR TITLE
[THC-111] Count returns distinct results by default

### DIFF
--- a/knowledgeBase/jupiterOne-query-language_(J1QL)/jupiterOne-query-language.md
+++ b/knowledgeBase/jupiterOne-query-language_(J1QL)/jupiterOne-query-language.md
@@ -830,6 +830,37 @@ return acct._type, acct.displayName, count(user)
 
 ##### The Simple Case
 
+`count` always returns the number of distinct entities or atrributes requested.
+
+With this data:
+| id | class | name | lead |
+|----|-------|------|------|
+| 1 | bitbucket_team | team1 | alice |
+| 2 | bitbucket_team | team2 | bob |
+| 3 | bitbucket_team | team3 | alice |
+
+and this query:
+
+```j1ql
+find
+  bitbucket_team as team
+return
+  count(team.lead)
+```
+
+the result will be:
+
+```json
+{
+  "type": "table",
+  "data": [
+    { "count(team.lead)": 2 },
+  ]
+}
+```
+
+##### Single grouping key
+
 For example, with the following query,
 
 ```j1ql


### PR DESCRIPTION
When returning count of an entity or attribute, count will always return distinct values. Added an example to explain this.