### PR TITLE
INT-6287 - Update Slack integration wording

### DIFF
--- a/knowledgeBase/APIs_and-integrations/business-tools/graph-slack.md
+++ b/knowledgeBase/APIs_and-integrations/business-tools/graph-slack.md
@@ -100,7 +100,7 @@ private channel as well.
 
 ## How to Uninstall
 
-1.  From the configuration **Gear Icon**, select **Integrations**.
+1.  From the top navigation of the J1 Search homepage, select **Integrations**.
 2.  Scroll to the **Slack** integration tile and click it.
 3.  Identify and click the **integration to delete**.
 4.  Click the **trash can** icon.

--- a/knowledgeBase/APIs_and-integrations/business-tools/graph-slack.md
+++ b/knowledgeBase/APIs_and-integrations/business-tools/graph-slack.md
@@ -1,4 +1,4 @@
-# Slack Integration with JupiterOne
+# JupiterOne integration for Slack
 
 ## Slack + JupiterOne Integration Benefits
 
@@ -38,7 +38,7 @@ ingesting relevant information and send notifications via the
 
 ### In Slack
 
-1.  First navigate to the JupiterOne Slack integration configuration page (see
+1.  First navigate to the JupiterOne integration for Slack configuration page (see
     detailed steps in the **In JupiterOne** section below)
 2.  Fill out relavant integration instance form information and OAuth scopes that
     you'd like the Slack app to request. All read scopes are used to ingest data
@@ -90,7 +90,7 @@ Additionally, see the
 for technical details on alert rule/action properties.
 
 JupiterOne can deliver Slack messages directly to any channel or to specific
-users in a Slack Channel once the JupiterOne Slack integration has been
+users in a Slack Channel once the JupiterOne integration for Slack has been
 configured via the JupiterOne web app. This will prompt the JupiterOne Slack app
 to be installed in your Workspace.
 

--- a/knowledgeBase/APIs_and-integrations/business-tools/graph-slack.md
+++ b/knowledgeBase/APIs_and-integrations/business-tools/graph-slack.md
@@ -1,4 +1,4 @@
-# JupiterOne integration for Slack
+# Slack
 
 ## Slack + JupiterOne Integration Benefits
 
@@ -64,7 +64,7 @@ recommended that an Administrator or Owner install the application.
 
 ### In JupiterOne
 
-1.  From the configuration **Gear Icon**, select **Integrations**.
+1.  From the top navigation of the J1 Search homepage, select **Integrations**.
 2.  Scroll to the **Slack** integration tile and click it.
 3.  Click the **Add Configuration** button and configure the following settings:
 


### PR DESCRIPTION
The Slack App Directory team has explicitly asked for this wording to be updated. See screenshot from their message:

<img width="747" alt="Screen Shot 2022-12-05 at 8 43 34 AM" src="https://user-images.githubusercontent.com/3771924/205651808-54d6c98f-4147-429d-8dea-e6c45c9510d3.png">

**NOTE**: The part about "long description" has been re-submitted to Slack on their end and is independent of our public JupiterOne documentation.