### PR TITLE
Revert "Fix format"

### DIFF
--- a/knowledgeBase/APIs/jupiterone-api.md
+++ b/knowledgeBase/APIs/jupiterone-api.md
@@ -80,20 +80,7 @@ curl --location --request POST 'https://graphql.us.jupiterone.io' \
 --header 'Jupiterone-Account: accountID' \
 --data-binary @- << EOF
 {
-  "query": 
-  	"query J1QL(
-  		$query: String!
-  		$cursor: String
-  		){
-        queryV1(
-        	query: $query
-			cursor: $cursor
-			) { 
-				type
-				data
-				cursor 
-			} 
-		}",
+  "query": "query J1QL(\$query: String!, \$cursor: String) {queryV1(query: \$query, cursor: \$cursor) { type data cursor } }",
   "variables": {
     "query": "find Domain"
   }


### PR DESCRIPTION
This reverts commit 1d07d642301e2f4e50dc5970be3136ee6be655de.

@janettelynch Looks like this change slipped in that I didn't catch it in the PR review for the `curl` command updates.