### PR TITLE
Add integration job ttl to integrations FAQ

### DIFF
--- a/knowledgeBase/APIs_and-integrations/other/faqs-integrations.md
+++ b/knowledgeBase/APIs_and-integrations/other/faqs-integrations.md
@@ -26,3 +26,7 @@ For **Okta**, you can set the `userType` property for the user to one of the fol
 - `generic`
 - `service`
 - `system`
+
+## WHy can I only see integration jobs for the past 30 days?
+
+JupiterOne uses a Time to Live (TTL) of 30 days for all integration jobs. Jobs older than 30 days are no longer available for review in JupiterOne.

--- a/knowledgeBase/APIs_and-integrations/other/faqs-integrations.md
+++ b/knowledgeBase/APIs_and-integrations/other/faqs-integrations.md
@@ -27,6 +27,6 @@ For **Okta**, you can set the `userType` property for the user to one of the fol
 - `service`
 - `system`
 
-## WHy can I only see integration jobs for the past 30 days?
+## Why can I only see integration jobs for the past 30 days?
 
 JupiterOne uses a Time to Live (TTL) of 30 days for all integration jobs. Jobs older than 30 days are no longer available for review in JupiterOne.


### PR DESCRIPTION
Customers were confused about why they did not see jobs from more than 30 days ago, so let's add some documentation. 