### PR TITLE
THC-1010 - document return clause behavior

### DIFF
--- a/knowledgeBase/APIs/jupiterone-api.md
+++ b/knowledgeBase/APIs/jupiterone-api.md
@@ -1,19 +1,19 @@
 # JupiterOne API
 
-The JupiterOne platform exposes a number of public GraphQL endpoints. 
+The JupiterOne platform exposes a number of public GraphQL endpoints.
 
 **Base URL**: `https://graphql.us.jupiterone.io`
 
 - For query and graph operations
 - For alerts and rules operations
 
-**Rate Limits**: Rate limiting is enforced based on your account tier: 
+**Rate Limits**: Rate limiting is enforced based on your account tier:
 
 - Free: 10/min, no burst
 - Freemium: 30/min, no burst
 - Enterprise: 30-60/min with burst
 
-A `429` HTTP response code indicates the limit has been reached. 
+A `429` HTTP response code indicates the limit has been reached.
 
 **Authentication**: The JupiterOne APIs use a Bearer Token to authenticate. Include the API key in the header as a Bearer Token. You also need to include `JupiterOne-Account` as a header parameter. You can find the `Jupiterone-Account` value in your account by running the following J1QL query:
 
@@ -106,9 +106,9 @@ Optionally, additional parameters can be provided:
 - `deferredResponse`: This option allows for a deferred response to be returned. When a deferred response is returned, a `url` pointing the state of the query is provided. API consumers should poll the status of the deferred query by requesting the given `url` until the `status` property of the returned JSON document has a value of `COMPLETED` (see example below). Upon completion of the query, the `url` will provide a link to the query results. The results contain the same `type`, `data`, and `cursor` fields that the non-deferred GraphQL response would contain. Allowed values are `DISABLED` and `FORCE`.
 - `flags`:
   - `computedProperties`: When set to `true`, vertices will be tagged with additional information to indicate if there are noteworthy traits that are worth surfacing.
-  - `rowMetadata`: When set to `true`, table results will return metadata about the requested objects under a `_meta` property.
-  - `variableResultSize`: When set to `true` the API will return the largest result size possible. Without this flag, the result size will be limited to 250 rows. This flag is recommended for use in cases where a larger result size is preferable and an indeterminate/variable number of return results is acceptable. 
-- `scopeFilters`: An array of `JSON` map of filters that define the desired vertex. They have precedence over filters supplied in the query.   
+  - `rowMetadata`: When set to `true`, table results will return metadata about the requested objects under a `_meta` property. Queries using the the `UNIQUE` keyword to deduplicate rows sets or aggregations (such as the `count` function) will not return a `_meta` property on each row.
+  - `variableResultSize`: When set to `true` the API will return the largest result size possible. Without this flag, the result size will be limited to 250 rows. This flag is recommended for use in cases where a larger result size is preferable and an indeterminate/variable number of return results is acceptable.
+- `scopeFilters`: An array of `JSON` map of filters that define the desired vertex. They have precedence over filters supplied in the query.
 
 **Note:**
 `variableResultSize` can increase the rate of your pagination flow because the API will return the largest number of rows possible per request. The exact number of rows returned will not always be the same, but will be larger than the default -- hence the name, _variable_ result size.
@@ -149,6 +149,7 @@ query J1QL($query: String!, $variables: JSON, $cursor: String, $scopeFilters: [J
     }
   ],
   "flags": {
+    "rowMetadata": true,
     "computedProperties": true
   }
 }
@@ -159,7 +160,26 @@ query J1QL($query: String!, $variables: JSON, $cursor: String, $scopeFilters: [J
 ```json
 {
   "type": "table",
-  "data": [{ "Person.name": "Mochi" }],
+  "data": [
+    {
+      "Person.name": "Mochi",
+      "_meta": {
+        "byAlias": {
+          "Person": {
+            "id": "952f0d8c-19dc-4dde-a3bf-e6ce0cda85a7",
+            "entity": {
+              "_id": "cdbceb28-e066-4006-9456-225ddb358d16"
+            },
+            "computed": {
+              "tags": [
+                "HasProblem"
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
   "cursor": "eyJjYWNoZUtleSI6IjFlNDg3MT..."
 }
 ```
@@ -3083,7 +3103,7 @@ Sample (S4): `createIamGroup`
 
 **Access All Actions and Resources**
 
-You can use an API token to access all actions and resources 
+You can use an API token to access all actions and resources
 
 
 
@@ -3164,7 +3184,7 @@ type permission = string; // must be a valid permission string
 | _Integrations_           |  READ  |       `accessIntegrations` |
 | _Endpoint Compliance_    |  READ  | `accessEndpointCompliance` |
 
-**Permission Strings: ADMIN** 
+**Permission Strings: ADMIN**
 
 | DISPLAY NAME (J1 APP)    | ACCESS |                PERMISSION |
 | :----------------------- | :----: | ------------------------: |

--- a/knowledgeBase/compliance_and-reporting/problems.md
+++ b/knowledgeBase/compliance_and-reporting/problems.md
@@ -1,8 +1,9 @@
 # Working with Problems
 
-JupiterOne groups [compliance gaps](./compliance-gap-analysis.md) and non-informational [rule alerts](../security-operations/manage-alerts.md) in a class called Problems. This concept enables you to see all your issues grouped together, making it easier to focus on what problems you must resolve in your environment. 
+JupiterOne groups [compliance gaps](./compliance-gap-analysis.md) and non-informational [rule alerts](../security-operations/manage-alerts.md) in a class called Problems. This concept enables you to see all your issues grouped together, making it easier to focus on what problems you must resolve in your environment.
 
-When a problem is detected, J1 automatically builds a relationship between the  `Problem`  asset, and the assets that have contributed to the detection of the problem. Assets in the J1 graph have a red dot next to them if a relationship to a problem exists. 
+When a problem is detected, J1 automatically builds a relationship between the  `Problem`  asset, and the assets that have contributed to the detection of the problem. Assets in the J1 graph have a red dot next to them if a relationship to a problem exists.
+This behavior is only supported when queries executed to detect problems are capable of returning references to affected entities (queries that do not use the `UNIQUE` keyword to receive deduplicated rows or perform aggregations).
 
   ![](../assets/graph-problems.png)
 

--- a/knowledgeBase/jupiterOne-query-language_(J1QL)/jupiterOne-query-language.md
+++ b/knowledgeBase/jupiterOne-query-language_(J1QL)/jupiterOne-query-language.md
@@ -46,10 +46,10 @@ Supported operators include:
 - `>` or `<` for **Number** or **Date** comparison.
 
 Note:
-- The property names and values are _case sensitive_. 
+- The property names and values are _case sensitive_.
 - **String** values must be wrapped in either single or double quotes - `"value"` or `'value'`.
 - **Boolean**, **Number**, and **Date** values must _not_ be wrapped in quotes.
-- The `undefined` keyword can be used to filter on the absence of a property. 
+- The `undefined` keyword can be used to filter on the absence of a property.
   For example: `FIND DataStore with encrypted=undefined`
 - If a property name contains special characters (e.g. `-` or `:`), you can wrap the property name in `[]`.  For example: `[tag.special-name]='something'`
 
@@ -218,20 +218,81 @@ By default, the entities and their properties found from the start of the traver
 To return properties from both the `User` and `Person` entities, define a selector for each and use them in the `RETURN` clause:
 
 ```j1ql
-FIND User as u that IS Person as p
+FIND User AS u THAT IS Person AS p
 RETURN u.username, p.firstName, p.lastName, p.email
 ```
 
+**Note**: When the `RETURN` statement is used with specified properties, the J1QL engine will pick out the requested attributes from each path traversed.
+Sometimes, the path to the end of the query can fork since there are multiple ways assets can relate to each other.
+This means that a `Person` having multiple `IS` relationships to `User` entities will have their `p.firstName`, `p.lastName`, and `p.email` values
+returned in each path through the graph that leads to a `User`.
+
+| u.username | p.firstName | p.lastName | p.email                        |
+|------------|-------------|------------|--------------------------------|
+| spiderman  | Peter       | Parker     | not.spiderman@example.com      |
+| batman     | Bruce       | Wayne      | totally.not.batman@example.com |
+| bwayne     | Bruce       | Wayne      | totally.not.batman@example.com |
+
 If a property name contains special characters (e.g. `-` or `:`), you can wrap the property name in `[]`.
 
-For example: `RETURN p.[special-name]='something'`
+For example: `RETURN p.[special-name]`
 
-Wildcard can be used to return all properties. For example:
+Wildcard can be used to return all properties for multiple entities in a flattened table. For example:
+
 ```j1ql
-FIND User as u that IS Person as p
+FIND User AS u THAT IS Person AS p
 RETURN u.*, p.*
 ```
+
 Using a wildcard to return all properties also returns all metadata properties associated with the selected entities. This feature is useful when you want to perform an analysis that involves metadata.
+
+##### Entity and Relationship References
+
+Using the `RETURN` clause, the J1QL query engine returns back only the requested information.
+Results would typically be returned like this via the API:
+
+```json
+{
+  "type": "table",
+  "data": [
+    { "User._type": "jupiterone_user", "Person.name": "Mochi" }
+  ]
+}
+```
+
+When executing queries via the application, additional metadata is returned back for each row with references
+to the entities and relationships traversed via the paths. This resides under a `_meta` property that is attached to each row
+in the query.
+
+```json
+{
+  "type": "table",
+  "data": [
+    {
+      "User._type": "jupiterone_user",
+      "Person.name": "Mochi",
+      "_meta": {
+        "byAlias": {
+          "User": {
+            "id": "f4b7cfbb-8532-dbcb-b244-e2864423fccd",
+            "entity": {
+              "_id": "4147b2bc-3b65-42a8-be50-164a45c4864d"
+            }
+          },
+          "Person": {
+            "id": "952f0d8c-19dc-4dde-a3bf-e6ce0cda85a7",
+            "entity": {
+              "_id": "cdbceb28-e066-4006-9456-225ddb358d16"
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+Please note that returning row metadata is not supported when `UNIQUE` keyword is used or an aggregation is performed.
 
 #### TO
 
@@ -256,18 +317,18 @@ FIND User THAT CONTRIBUTES CodeRepo
 
 #### Commenting
 
-J1QL supports commenting in queries anywhere in J1 using the format `/* insert comment here */`.  
-For example: 
+J1QL supports commenting in queries anywhere in J1 using the format `/* insert comment here */`.
+For example:
 
 ```j1ql
-FIND aws_security_group 
-	WITH displayName ~='elb' /*ELB Security Group*/ 
+FIND aws_security_group
+	WITH displayName ~='elb' /*ELB Security Group*/
 	OR displayName ~='lambda' /*Lambda Security Group*/
 ```
 
 ## Mathematical Expressions
 
-J1QL supports some mathematical expressions as functions. 
+J1QL supports some mathematical expressions as functions.
 
 | Function  | Description                                                  | Example Query                                                |
 | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
@@ -285,7 +346,7 @@ J1QL supports some mathematical expressions as functions.
 Click the download icon ![](../assets/icons/download.png) to download all assets or a selected asset as a CSV file. You are notified in the Notifications ![](../assets/icons/bell.png) panel in the top-right of the top navigation bar when your download is complete and ready for you to download.
 
 
-![](../assets/query-download.png) 
+![](../assets/query-download.png)
 
 
 
@@ -498,6 +559,9 @@ There are plans to support the following aggregations:
 
 - `count(*)` - for determining the count of all other entities related to a given entity.
 
+Please note that performing aggregations will cause the `_meta` property
+returned for each row of data to be stripped out.
+
 ## Scalar Functions
 
 The ability to format and/or to perform calculations on row level columns can be accomplished through **Scalar Functions**.
@@ -515,7 +579,7 @@ Note: If this function receives a number or boolean value, the `concat` intuitiv
 - Number values: e.g. `123`
 - Boolean values: e.g. `true`
 
-Example: 
+Example:
 
 ```
 FIND
@@ -535,7 +599,7 @@ Example:
 ```
 FIND UNIQUE User as u
 THAT IS Person as p
-RETURN p.displayName, merge(p.email, u.email, u.publicEmail) as “Email List” (edited) 
+RETURN p.displayName, merge(p.email, u.email, u.publicEmail) as “Email List” (edited)
 ```
 
 
@@ -571,6 +635,39 @@ RETURN
 ```
 _Limitation: `UNIQUE` keyword **must** be used together with `RETURN`._
 
+For example, the following query may return multiple rows containing the same
+values. In the below example, Peter Parker may using the same username
+across with different applications.
+
+```j1ql
+FIND User AS u THAT IS Person AS p
+RETURN u.username, p.firstName, p.lastName, p.email
+```
+
+| u.username | p.firstName | p.lastName | p.email                        |
+|------------|-------------|------------|--------------------------------|
+| spiderman  | Peter       | Parker     | not.spiderman@example.com      |
+| spiderman  | Peter       | Parker     | not.spiderman@example.com      |
+| batman     | Bruce       | Wayne      | totally.not.batman@example.com |
+| bwayne     | Bruce       | Wayne      | totally.not.batman@example.com |
+
+Modifying the query to leverage the `UNIQUE` keyword will make the
+J1QL engine deduplicate rows.
+
+```j1ql
+FIND UNIQUE User AS u THAT IS Person AS p
+RETURN u.username, p.firstName, p.lastName, p.email
+```
+
+| u.username | p.firstName | p.lastName | p.email                        |
+|------------|-------------|------------|--------------------------------|
+| spiderman  | Peter       | Parker     | not.spiderman@example.com      |
+| batman     | Bruce       | Wayne      | totally.not.batman@example.com |
+| bwayne     | Bruce       | Wayne      | totally.not.batman@example.com |
+
+Please note that deduplicating rows using the `UNIQUE` keyword will cause the
+`_meta` property returned for each row of data to be stripped out.
+
 ### `MERGE`
 
 The function `MERGE()` allows you to merge multiple properties into a single property list. You can now combine multiple (defined) properties into a single property without having to choose to return one property or another.
@@ -580,10 +677,8 @@ Example:
 ```
 FIND UNIQUE User as u
 THAT IS Person as p
-RETURN p.displayName, merge(p.email, u.email, u.publicEmail) as “Email List” (edited) 
+RETURN p.displayName, merge(p.email, u.email, u.publicEmail) as “Email List” (edited)
 ```
-
-
 
 ## Math Operations
 

--- a/knowledgeBase/jupiterOne-query-language_(J1QL)/jupiterOne-query-language.md
+++ b/knowledgeBase/jupiterOne-query-language_(J1QL)/jupiterOne-query-language.md
@@ -692,9 +692,9 @@ The function `MERGE()` allows you to merge multiple properties into a single pro
 Example:
 
 ```
-FIND UNIQUE User as u
-THAT IS Person as p
-RETURN p.displayName, merge(p.email, u.email, u.publicEmail) as “Email List” (edited)
+FIND UNIQUE User AS u
+THAT IS Person AS p
+RETURN p.displayName, merge(p.email, u.email, u.publicEmail) AS “Email List” (edited)
 ```
 
 ## Math Operations

--- a/knowledgeBase/jupiterOne-query-language_(J1QL)/jupiterOne-query-language.md
+++ b/knowledgeBase/jupiterOne-query-language_(J1QL)/jupiterOne-query-language.md
@@ -636,8 +636,8 @@ RETURN
 _Limitation: `UNIQUE` keyword **must** be used together with `RETURN`._
 
 For example, the following query may return multiple rows containing the same
-values. In the below example, Peter Parker may using the same username
-across with different applications.
+values. In the below example, Peter Parker may use the same username
+across different applications.
 
 ```j1ql
 FIND User AS u THAT IS Person AS p


### PR DESCRIPTION
We've noticed that there's some confusion around how the `RETURN` clause and `UNIQUE` clauses function. This PR adds a bit more detail to the `RETURN` and `UNIQUE` clauses to help clarify the behavior of the language. 

This also adds some documentation around the row metadata, with notes around situations when the `_meta` property does not get returned.