### PR TITLE
[APP-11279] trigger actions on new entities only field

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,15 +9,15 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: [ "vanilla-staging" ]
+    branches: ['vanilla-staging']
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "vanilla-staging" ]
-    
+    branches: ['vanilla-staging']
+
 jobs:
   analyze:
     name: Analyze
@@ -30,41 +30,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: ['javascript']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        queries: security-extended,security-and-quality
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          queries: security-extended,security-and-quality
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/integrations.config.yaml
+++ b/integrations.config.yaml
@@ -332,4 +332,4 @@ integrations:
   - projectName: graph-detectify
     displayName: Detectify
     knowledgeCategoriesPaths: APIs_and-integrations/application-security
-  - 
+  -

--- a/knowledgeBase/APIs/alert-rule-schema.md
+++ b/knowledgeBase/APIs/alert-rule-schema.md
@@ -80,20 +80,21 @@ example:
 
 ## Rule Properties
 
-| Property           | Type              | Description                                                                                                                                                                 |
-| ------------------ | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`               | `string`          | Auto-generated, globally unique ID of each rule.                                                                                                                            |
-| `version`          | `number`          | Current version of the rule. Incremented each time the rule is updated.                                                                                                     |
-| `name`             | `string`          | Name of the rule, which is unique to each account.                                                                                                                          |
-| `description`      | `string`          | Optional description of the rule.                                                                                                                                           |
-| `specVersion`      | `number`          | Rule evaluation version in the case of breaking changes.                                                                                                                    |
-| `pollingInterval`  | `PollingInterval` | Optional frequency of automated rule evaluation. Defaults to `ONE_DAY`.                                                                                                     |
-| `question`         | `Question`        | Contains properties related to queries used in the rule evaluation.                                                                                                         |
-| `questionId`       | `string`          | A known unique ID for a question in the question library.                                                                                                                   |
-| `operations`       | `RuleOperation[]` | Actions that are executed when a corresponding condition is met.                                                                                                            |
-| `templates`        | `object`          | Optional key/value pairs of template name to template.                                                                                                                      |
-| `outputs`          | `string[]`        | Names of properties that can be used throughout the rule evaluation process and will be included in each record of a rule evaluation (for example, `queries.query0.total`). |
-<!-- TODO: insert notifyOnFailure boolean flag when feature is GA -->
+| Property                          | Type              | Description                                                                                                                                                                 |
+| --------------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                              | `string`          | Auto-generated, globally unique ID of each rule.                                                                                                                            |
+| `version`                         | `number`          | Current version of the rule. Incremented each time the rule is updated.                                                                                                     |
+| `name`                            | `string`          | Name of the rule, which is unique to each account.                                                                                                                          |
+| `description`                     | `string`          | Optional description of the rule.                                                                                                                                           |
+| `specVersion`                     | `number`          | Rule evaluation version in the case of breaking changes. This should always be `1`.                                                                                         |
+| `pollingInterval`                 | `PollingInterval` | Optional frequency of automated rule evaluation. Defaults to `ONE_DAY`.                                                                                                     |
+| `question`                        | `Question`        | Contains properties related to queries used in the rule evaluation.                                                                                                         |
+| `questionId`                      | `string`          | A known unique ID for a question in the question library.                                                                                                                   |
+| `operations`                      | `RuleOperation[]` | Actions that are executed when a corresponding condition is met.                                                                                                            |
+| `templates`                       | `object`          | Optional key/value pairs of template name to template.                                                                                                                      |
+| `outputs`                         | `string[]`        | Names of properties that can be used throughout the rule evaluation process and will be included in each record of a rule evaluation (for example, `queries.query0.total`). |
+| `notifyOnFailure`                 | `boolean`         | Will send a notification to stakeholders (account admins, assigned users) if the rule query or any of its actions does not succeed.                                         |
+| `triggerActionsOnNewEntitiesOnly` | `boolean`         | Will only trigger actions to be run when entities that did not exist during the previous rule evaluation appear in the question results.                                    |
 
 ### Type: PollingInterval
 

--- a/knowledgeBase/APIs_and-integrations/other/faqs-integrations.md
+++ b/knowledgeBase/APIs_and-integrations/other/faqs-integrations.md
@@ -26,3 +26,7 @@ For **Okta**, you can set the `userType` property for the user to one of the fol
 - `generic`
 - `service`
 - `system`
+
+## WHy can I only see integration jobs for the past 30 days?
+
+JupiterOne uses a Time to Live (TTL) of 30 days for all integration jobs. Jobs older than 30 days are no longer available for review in JupiterOne.

--- a/knowledgeBase/APIs_and-integrations/other/faqs-integrations.md
+++ b/knowledgeBase/APIs_and-integrations/other/faqs-integrations.md
@@ -27,6 +27,6 @@ For **Okta**, you can set the `userType` property for the user to one of the fol
 - `service`
 - `system`
 
-## WHy can I only see integration jobs for the past 30 days?
+## Why can I only see integration jobs for the past 30 days?
 
 JupiterOne uses a Time to Live (TTL) of 30 days for all integration jobs. Jobs older than 30 days are no longer available for review in JupiterOne.


### PR DESCRIPTION
The `triggerActionsOnNewEntitiesOnly` feature is scheduled for 4/11, I've also uncommented the `notifyOnFailure` field