### PR TITLE
Update Rapid7 permissions req from Site Owner -> Global Admin

### DIFF
--- a/knowledgeBase/APIs_and-integrations/endpoint-security/graph-rapid7.md
+++ b/knowledgeBase/APIs_and-integrations/endpoint-security/graph-rapid7.md
@@ -38,8 +38,8 @@ Jupiterone requires the following information to complete authentication:
     *   The publicly-accessible socket (host:port) of your InsightVM Security
         Console. e.g. <hostname>:3780.
 2.  An InsightVM Username and Password
-    *   Use an existing user or create a user that has at least the
-        [Security Manager and Site Owner Role](https://docs.rapid7.com/insightvm/managing-users-and-authentication/#security-manager-and-site-owner)
+    *   Use an existing user or create a user that has the
+        [Global Administrator Role](https://docs.rapid7.com/insightvm/managing-users-and-authentication/#global-administrator)
 
 ### In JupiterOne
 


### PR DESCRIPTION
The required permission was updated in the `graph-rapid7` project in December via this PR: https://github.com/JupiterOne/graph-rapid7/pull/67/files

Unfortunately, it seems that the update never made it into this project, and has caused some confusion for customers. Manually updating the `graph-rapid7` docs as a result.